### PR TITLE
Pointer safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # go-mpatch
 Go library for monkey patching
 
+
 Library inspired by the blog post: https://bou.ke/blog/monkey-patching-in-go/

--- a/patcher_test.go
+++ b/patcher_test.go
@@ -1,7 +1,9 @@
 package mpatch
 
 import (
+	"fmt"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -92,4 +94,30 @@ func TestInstanceValuePatcher(t *testing.T) {
 	if mStruct.ValueMethod() != 1 {
 		t.Fatal("The unpatch did not work")
 	}
+}
+
+type myType struct {
+}
+
+var slice []int
+
+//go:noinline
+//go:nosplit
+func TestGarbageCollector(t *testing.T) {
+
+	for i := 0; i < 10000000; i++ {
+		slice = append(slice, i)
+	}
+	aVal := &myType{}
+	ptr01 := reflect.ValueOf(aVal).Pointer()
+	slice = nil
+	runtime.GC()
+	for i := 0; i < 10000000; i++ {
+		slice = append(slice, i)
+	}
+	slice = nil
+	runtime.GC()
+	ptr02 := reflect.ValueOf(aVal).Pointer()
+
+	fmt.Println(ptr01, ptr02)
 }

--- a/patcher_unix.go
+++ b/patcher_unix.go
@@ -2,14 +2,28 @@
 
 package mpatch
 
-import "syscall"
+import (
+	"reflect"
+	"syscall"
+	"unsafe"
+)
 
 var writeAccess = syscall.PROT_READ | syscall.PROT_WRITE | syscall.PROT_EXEC
 var readAccess = syscall.PROT_READ | syscall.PROT_EXEC
 
-func callMProtect(addr uintptr, length int, prot int) error {
-	for p := getPageStartPtr(addr); p < addr+uintptr(length); p += uintptr(pageSize) {
-		page := getMemorySliceFromPointer(p, pageSize)
+//go:nosplit
+func getMemorySliceFromUintptr(p uintptr, length int) []byte {
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: p,
+		Len:  length,
+		Cap:  length,
+	}))
+}
+
+//go:nosplit
+func callMProtect(addr unsafe.Pointer, length int, prot int) error {
+	for p := uintptr(addr) & ^(uintptr(pageSize - 1)); p < uintptr(addr)+uintptr(length); p += uintptr(pageSize) {
+		page := getMemorySliceFromUintptr(p, pageSize)
 		err := syscall.Mprotect(page, prot)
 		if err != nil {
 			return err
@@ -18,7 +32,7 @@ func callMProtect(addr uintptr, length int, prot int) error {
 	return nil
 }
 
-func copyDataToPtr(ptr uintptr, data []byte) error {
+func copyDataToPtr(ptr unsafe.Pointer, data []byte) error {
 	dataLength := len(data)
 	ptrByteSlice := getMemorySliceFromPointer(ptr, len(data))
 	err := callMProtect(ptr, dataLength, writeAccess)

--- a/patcher_unsupported.go
+++ b/patcher_unsupported.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"unsafe"
 )
 
 // Gets the jump function rewrite bytes
-func getJumpFuncBytes(to uintptr) ([]byte, error) {
+//go:nosplit
+func getJumpFuncBytes(to unsafe.Pointer) ([]byte, error) {
 	return nil, errors.New(fmt.Sprintf("Unsupported architecture: %s", runtime.GOARCH))
 }

--- a/patcher_windows.go
+++ b/patcher_windows.go
@@ -11,15 +11,15 @@ const pageExecuteReadAndWrite = 0x40
 
 var virtualProtectProc = syscall.NewLazyDLL("kernel32.dll").NewProc("VirtualProtect")
 
-func callVirtualProtect(lpAddress uintptr, dwSize int, flNewProtect uint32, lpflOldProtect unsafe.Pointer) error {
-	ret, _, _ := virtualProtectProc.Call(lpAddress, uintptr(dwSize), uintptr(flNewProtect), uintptr(lpflOldProtect))
+func callVirtualProtect(lpAddress unsafe.Pointer, dwSize int, flNewProtect uint32, lpflOldProtect unsafe.Pointer) error {
+	ret, _, _ := virtualProtectProc.Call(uintptr(lpAddress), uintptr(dwSize), uintptr(flNewProtect), uintptr(lpflOldProtect))
 	if ret == 0 {
 		return syscall.GetLastError()
 	}
 	return nil
 }
 
-func copyDataToPtr(ptr uintptr, data []byte) error {
+func copyDataToPtr(ptr unsafe.Pointer, data []byte) error {
 	var oldPerms, tmp uint32
 	dataLength := len(data)
 	ptrByteSlice := getMemorySliceFromPointer(ptr, len(data))

--- a/patcher_x32.go
+++ b/patcher_x32.go
@@ -2,14 +2,17 @@
 
 package mpatch
 
+import "unsafe"
+
 // Gets the jump function rewrite bytes
-func getJumpFuncBytes(to uintptr) ([]byte, error) {
+//go:nosplit
+func getJumpFuncBytes(to unsafe.Pointer) ([]byte, error) {
 	return []byte{
 		0xBA,
-		byte(to),
-		byte(to >> 8),
-		byte(to >> 16),
-		byte(to >> 24),
+		byte(uintptr(to)),
+		byte(uintptr(to) >> 8),
+		byte(uintptr(to) >> 16),
+		byte(uintptr(to) >> 24),
 		0xFF, 0x22,
 	}, nil
 }

--- a/patcher_x64.go
+++ b/patcher_x64.go
@@ -2,18 +2,21 @@
 
 package mpatch
 
+import "unsafe"
+
 // Gets the jump function rewrite bytes
-func getJumpFuncBytes(to uintptr) ([]byte, error) {
+//go:nosplit
+func getJumpFuncBytes(to unsafe.Pointer) ([]byte, error) {
 	return []byte{
 		0x48, 0xBA,
-		byte(to),
-		byte(to >> 8),
-		byte(to >> 16),
-		byte(to >> 24),
-		byte(to >> 32),
-		byte(to >> 40),
-		byte(to >> 48),
-		byte(to >> 56),
+		byte(uintptr(to)),
+		byte(uintptr(to) >> 8),
+		byte(uintptr(to) >> 16),
+		byte(uintptr(to) >> 24),
+		byte(uintptr(to) >> 32),
+		byte(uintptr(to) >> 40),
+		byte(uintptr(to) >> 48),
+		byte(uintptr(to) >> 56),
 		0xFF, 0x22,
 	}, nil
 }


### PR DESCRIPTION
This PR removes the majority of `uintptr` data type and replace it with `unsafe.Pointer` so the GC keeps track of those type and updates the pointer values if required.

Some `uintptr` references need to be kept because the pointer arithmetic needed to load the system memory pages to rewrite the method bodies. These `uintptr` shouldn't be affected by the GC because contains address to `read-only` executable memory page, and that space shouldn't be moved by the GC.

The use of `//go:nosplit` is intended because has the side effect of avoid the GC

> The //go:nosplit comment tells the compiler to not check for stack overflow when entering the function. That has the side effect that the garbage collector will not run when entering the function. (https://stackoverflow.com/a/32701024) 