### PR TITLE
Revert breaking api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func methodB() int { return 2 }
 
 func TestPatcherUsingReflect(t *testing.T) {
 	reflectA := reflect.ValueOf(methodA)
-	patch, err := mPatch.PatchMethodByReflect(reflectA, methodB)
+	patch, err := mPatch.PatchMethodByReflectValue(reflectA, methodB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func methodA() int { return 1 }
 
 func TestPatcherUsingMakeFunc(t *testing.T) {
 	reflectA := reflect.ValueOf(methodA)
-	patch, err := PatchMethodWithMakeFunc(reflectA,
+	patch, err := PatchMethodWithMakeFuncValue(reflectA,
 		func(args []reflect.Value) (results []reflect.Value) {
 			return []reflect.Value{reflect.ValueOf(42)}
 		})

--- a/patcher_test.go
+++ b/patcher_test.go
@@ -46,7 +46,7 @@ func TestPatcher(t *testing.T) {
 
 func TestPatcherUsingReflect(t *testing.T) {
 	reflectA := reflect.ValueOf(methodA)
-	patch, err := PatchMethodByReflect(reflectA, methodB)
+	patch, err := PatchMethodByReflectValue(reflectA, methodB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestPatcherUsingReflect(t *testing.T) {
 
 func TestPatcherUsingMakeFunc(t *testing.T) {
 	reflectA := reflect.ValueOf(methodA)
-	patch, err := PatchMethodWithMakeFunc(reflectA,
+	patch, err := PatchMethodWithMakeFuncValue(reflectA,
 		func(args []reflect.Value) (results []reflect.Value) {
 			return []reflect.Value{reflect.ValueOf(42)}
 		})


### PR DESCRIPTION
Recent release introduced some breaking api changes as a patch release, causing the scope go agent to fail. This PR revert the change.

This PR is being tested in: https://github.com/undefinedlabs/scope-go-agent/pull/254/commits/aaacf615e42ee5df14d218e6cb76320096fbcd00