### PR TITLE
Add new go versions to the github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go_version: [1.7, 1.8, 1.9, "1.10", 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17]
+        go_version: [1.7, 1.8, 1.9, "1.10", 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         go_version: [1.7, 1.8, 1.9, "1.10", 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go ${{ matrix.go_version }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Go library for monkey patching
 
 ## Compatibility
 
-- **Go version:** tested from `go1.7` to `go1.17-beta`
+- **Go version:** tested from `go1.7` to `go1.19`
 - **Architectures:** `x86`, `amd64`
 - **Operating systems:** tested in `macos`, `linux` and `windows`. 
 


### PR DESCRIPTION
This PR adds tests up to go version 1.19